### PR TITLE
Create alarm_automation

### DIFF
--- a/Home Assistant/alarm_automation
+++ b/Home Assistant/alarm_automation
@@ -1,0 +1,12 @@
+- alias: alarm post to mqtt
+  description: ''
+  trigger:
+  - platform: state
+    entity_id: alarm_control_panel.home_alarm
+  condition: []
+  action:
+  - service: mqtt.publish
+    data:
+      topic: alarm
+      payload: '{{trigger.to_state.state}}'
+  mode: single


### PR DESCRIPTION
This Home Assistant automation, requires MQTT. It pushes the state of the alarm when it's changed.